### PR TITLE
feat(post): implement post deletion functionality

### DIFF
--- a/post_to_delete_response.json
+++ b/post_to_delete_response.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "post": {
+      "author_id": "683c2cc89c8c284ebb0eb0c3",
+      "comment_count": 0,
+      "community_id": "683c9e50cc1a082b63ff4295",
+      "community_name": "DevOps Voting Arena",
+      "community_slug": "devops-voting-arena",
+      "content_text": "This post is destined for deletion to test the API.",
+      "content_type": "text",
+      "created_at": "2025-06-01T18:57:02.900604",
+      "downvotes": 0,
+      "id": "683ca27e952ec746cf6076d5",
+      "image_url": null,
+      "last_activity_at": "2025-06-01T18:57:02.904269",
+      "link_url": null,
+      "tags": [],
+      "title": "Post to be Deleted Soon",
+      "updated_at": "2025-06-01T18:57:02.900613",
+      "upvotes": 0,
+      "user_vote": null
+    }
+  },
+  "status": "success"
+}


### PR DESCRIPTION
- Added a static method in the Post model to handle the deletion of posts, including validation for post and user IDs, and authorization checks.
- Implemented an API route for deleting a post, allowing users to remove their own posts along with associated comments.
- Enhanced error handling for various deletion scenarios, including invalid IDs and permission issues.
- Introduced a new JSON response structure for the deletion operation, providing meaningful feedback on success or failure.